### PR TITLE
Make mailcow hostname configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,12 +16,13 @@ This role will setup a mailcow dockerized email server.
 | docker-compose | docker-compose is needed               |
 
 ## Notes
-this role will use the `inventory_hostname` as mailcow hostname, this means that you have to use the full qualified domain name as your inventory hostname e.g. `mail.mailcow.tld`.
+this role will use by default the `inventory_hostname` as mailcow hostname, this means that you have to use the full qualified domain name as your inventory hostname e.g. `mail.mailcow.tld` or you set `mailcow__hostname` to the correct FQDN.
 
 ## Variables
 
 |                   name                    |                                   purpose                                   | default value |    note     |
 |:-----------------------------------------:|:---------------------------------------------------------------------------:|:-------------:|:-----------:|
+|           `mailcow__hostname `            | sets MAILCOW_HOSTNAME                                                | `inventory_hostname` | needs to be an full qualified domain name |
 |          `mailcow__git_version`           |                   checkout a specific version of mailcow                    |   `master`    |             |
 |            `mailcow__timezone`            | used to set the timezone your mailcow runs in during the config generation  |    not set    | must be set |
 |             `mailcow__theme`              |             set the default mailcow theme in vars.local.inc.php             |    `lumen`    |             |

--- a/defaults/main/main.yml
+++ b/defaults/main/main.yml
@@ -1,5 +1,7 @@
 ---
 
+mailcow__hostname: "{{ inventory_hostname }}"
+
 mailcow__git_version: master
 
 mailcow__timezone: Europe/Berlin

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -31,7 +31,7 @@
 - name: Generate mailcow.conf file
   shell: ./generate_config.sh
   environment:
-    MAILCOW_HOSTNAME: "{{ inventory_hostname }}"
+    MAILCOW_HOSTNAME: "{{ mailcow__hostname }}"
     MAILCOW_TZ: "{{ mailcow__timezone }}"
   args:
     executable: /bin/bash


### PR DESCRIPTION
I added an variable `mailcow__hostname` so i can configure the Hostname in my playbooks. It defaults to `inventory_hostname` so there is no change in the default behaviour. Also updated the README accordingly.