### PR TITLE
- Fixed generation of mailcow.conf file with accepting anything interactive shell suggests

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -29,7 +29,7 @@
   when: not mailcow_installed.stat.exists
 
 - name: Generate mailcow.conf file
-  shell: ./generate_config.sh
+  shell: yes "" | ./generate_config.sh
   environment:
     MAILCOW_HOSTNAME: "{{ mailcow__hostname }}"
     MAILCOW_TZ: "{{ mailcow__timezone }}"


### PR DESCRIPTION
`generate_config.sh` might require user input (even with env variables set):
- https://github.com/mailcow/mailcow-dockerized/blob/master/generate_config.sh#L68
- https://github.com/mailcow/mailcow-dockerized/blob/master/generate_config.sh#L91

I modified task "Generate mailcow.conf file" to accept anything interactive shell suggests.