### PR TITLE
netaddr package required

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -9,7 +9,7 @@
 - name: Install requiered pip packages
   become: yes
   pip:
-    name: ['docker','docker-compose']
+    name: ['docker','docker-compose', 'netaddr']
     state: present
 
 - name: Check if mailcow installation directory exists


### PR DESCRIPTION
In my case, I get error

TASK [mailcow.mailcow_ansiblerole : Configure HTTP_BIND] ************************************************************************************************************************************************************************************
fatal: [localhost]: FAILED! => {"msg": "The ipaddr filter requires python's netaddr be installed on the ansible controller"}

I suggest a fix