### PR TITLE
Use correct ipaddr module

### DIFF
--- a/tasks/mailcowconf.yml
+++ b/tasks/mailcowconf.yml
@@ -11,7 +11,7 @@
   replace:
     path: "{{ mailcow__install_path }}/mailcow.conf"
     regexp: "^HTTP_BIND=.*"
-    replace: "HTTP_BIND={{ mailcow__config_http_bind | ipaddr }}"
+    replace: "HTTP_BIND={{ mailcow__config_http_bind | ansible.utils.ipaddr }}"
   notify: Recreate mailcow
 
 - name: Configure HTTPS_PORT
@@ -25,7 +25,7 @@
   replace:
     path: "{{ mailcow__install_path }}/mailcow.conf"
     regexp: "^HTTPS_BIND=.*"
-    replace: "HTTPS_BIND={{ mailcow__config_https_bind | ipaddr }}"
+    replace: "HTTPS_BIND={{ mailcow__config_https_bind | ansible.utils.ipaddr }}"
   notify: Recreate mailcow
 
 - name: Configure ACL_ANYONE


### PR DESCRIPTION
Replace "ansible.netcommon.ipaddr" with "ansible.utils.ipaddr" since netcommon.ipaddr is deprecated and will be removed after 2024-01-01.

Currently, the module shows the following warning: `[DEPRECATION WARNING]: Use 'ansible.utils.ipaddr' module instead. This feature will be removed from ansible.netcommon in a release after 2024-01-01. Deprecation warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.`