### PR TITLE
Add changed_when to Update Mailcow Task

### DIFF
--- a/tasks/update.yml
+++ b/tasks/update.yml
@@ -18,6 +18,7 @@
   args:
     executable: /bin/bash
   register: mailcow_update
+  changed_when: 'not "No updates are available" in mailcow_update.stdout'
   tags:
     - skip_ansible_lint
 
@@ -31,3 +32,4 @@
     content: "{{ mailcow_update.stdout }}"
     dest: "/var/log/mailcow-update/update-{{ ansible_date_time.iso8601_basic_short }}.log"
   no_log: True
+  when: 'not "No updates are available" in mailcow_update.stdout'


### PR DESCRIPTION
The update mailcow task now only reports changed when an update is actually available. Logging is also reduced to not store logs when no update was available.