### PR TITLE
Added environment variable

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -27,6 +27,7 @@
   environment:
     MAILCOW_HOSTNAME: "{{ mailcow__hostname }}"
     MAILCOW_TZ: "{{ mailcow__timezone }}"
+    MAILCOW_BRANCH: "{{ mailcow__git_version }}"
   args:
     executable: /bin/bash
     chdir: "{{ mailcow__install_path }}"


### PR DESCRIPTION
https://github.com/mailcow/mailcow-dockerized/pull/4725 prevents [mailcow-ansiblerole](https://github.com/mailcow/mailcow-ansiblerole) from installing mailcow automatically by adding a read statement (https://github.com/mailcow/mailcow-dockerized/commit/4f380debb5a1b4e0079dde717ed3c6a455629b43#diff-be47f8b7221a40f99901465896a1702267321312166e16282e83fb0a313854ceR144) without giving the option to answer the question with environment variables.

This can be fixed by https://github.com/mailcow/mailcow-dockerized/pull/4741. Therefore I added the environment variable `MAILCOW_BRANCH`.