### PR TITLE
Fix For Ansible Lint

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -2,6 +2,8 @@
 galaxy_info:
   author: The mailcow maintainers
   description: Setup mailcow dockerized using ansible
+  role_name: mailcow
+  namespace: mailcow
   min_ansible_version: 2.11
   license: GNU General Public License 3
   platforms:


### PR DESCRIPTION
as now role_name and namespace are mandatory