### PR TITLE
Fix container name used as update condition for docker compose v2 

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This role will setup a mailcow dockerized email server.
 ## Prerequisites
 
 - Up and running Ubuntu/Debian host (other distributions not supported/tested for now)
-- Docker Compose v2 is requiered!
+- Docker Compose v2 is required!
 
 ## Requirements
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -53,7 +53,7 @@
 - name: Check if mailcow containers are running
   become: yes
   community.docker.docker_container_info:
-    name: "{{ mailcow__docker_compose_project_name }}_nginx-mailcow_1"
+    name: "{{ mailcow__docker_compose_project_name }}-nginx-mailcow-1"
   register: mailcow_running
 
 - name: Start mailcow container stack


### PR DESCRIPTION
As of the README docker compose v2 is required. In v2 the separator for container names changed from '_' to '-' (for both, the standalone and the plugin version).

Fixes #30 

 