### PR TITLE
Publish to Galaxy using Github Actions

### DIFF
--- a/.github/workflows/galaxy.yml
+++ b/.github/workflows/galaxy.yml
@@ -1,0 +1,16 @@
+name: Publish to Galaxy
+on:
+  workflow_run:
+    workflows: [Ansible Lint]
+    types: [completed]
+    branches: [master]
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    steps:
+      - name: galaxy
+        uses: robertdebock/galaxy-action@1.2.0
+        with:
+          galaxy_api_key: ${{ secrets.GALAXY_API_KEY }}


### PR DESCRIPTION
Requires #32.
Requires `secrets.GALAXY_API_KEY` to be set to the Galaxy API Token of the mailcow Account.

Fixes #29