### PR TITLE
Changed update script input for native ipv6

### DIFF
--- a/templates/updater.sh.j2
+++ b/templates/updater.sh.j2
@@ -12,7 +12,7 @@ if ./update.sh -c | grep -q 'Updated code is available'; then
   echo "Upgrading Mailcow"
 
   echo "Installing updates"
-  echo 'y' | ./update.sh
+  printf "%s\n" "y" "y" | ./update.sh
 
   echo "Collecting Gargabe"
   echo 'y' | ./update.sh --gc


### PR DESCRIPTION
This will add another "yes"-input to the update script to enable native ipv6 networking if available (recommended).

see https://github.com/mailcow/mailcow-dockerized/blob/master/update.sh#L101 

Seems like it makes no difference if the marked read is not being triggered. The last "yes" input will just go to void.