### PR TITLE
docker network configurable via ansible vars

### DIFF
--- a/defaults/main/mailcow.yml
+++ b/defaults/main/mailcow.yml
@@ -109,3 +109,9 @@ mailcow__config_log_lines: 9999
 
 # SOGo session timeout in minutes
 mailcow__config_sogo_expire_session: 480
+
+#ipv4 network base for docker network
+mailcow__docker_network_ipv4: 172.22.1
+
+#ipv6 ip range for docker network
+mailcow__docker_network_ipv6: fd4d:6169:6c63:6f77::/64

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -6,6 +6,9 @@
     docker-compose --project-name {{ mailcow__docker_compose_project_name }} restart
   args:
     chdir: "{{ mailcow__install_path }}"
+  environment:
+    IPV4_NETWORK: "{{ mailcow__docker_network_ipv4 }}"
+    IPV6_NETWORK: "{{ mailcow__docker_network_ipv6 }}"
 
 - name: Recreate mailcow
   become: yes
@@ -14,6 +17,9 @@
     docker-compose --project-name {{ mailcow__docker_compose_project_name }} up -d
   args:
     chdir: "{{ mailcow__install_path }}"
+  environment:
+    IPV4_NETWORK: "{{ mailcow__docker_network_ipv4 }}"
+    IPV6_NETWORK: "{{ mailcow__docker_network_ipv6 }}"
 
 - name: Restart mailcow rspamd
   become: yes
@@ -21,3 +27,6 @@
     docker-compose --project-name {{ mailcow__docker_compose_project_name }} restart rspamd-mailcow
   args:
     chdir: "{{ mailcow__install_path }}"
+  environment:
+    IPV4_NETWORK: "{{ mailcow__docker_network_ipv4 }}"
+    IPV6_NETWORK: "{{ mailcow__docker_network_ipv6 }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -62,6 +62,9 @@
     docker-compose --project-name {{ mailcow__docker_compose_project_name }} up -d
   args:
     chdir: "{{ mailcow__install_path }}"
+  environment:
+    IPV4_NETWORK: "{{ mailcow__docker_network_ipv4 }}"
+    IPV6_NETWORK: "{{ mailcow__docker_network_ipv6 }}"
   when: not mailcow_running.exists
 
 - name: Update mailcow


### PR DESCRIPTION
currently it is not possible to configure the the docker network ip ranges via ansible variables which can break the ansible run on hosts with multiple already existing networks.

This change will set the environment variables for the IPV4_NETWORK and IPV6_NETWORK on docker-compose invocation.
