### PR TITLE
Add the Ability to disable IPv6

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ This role will use by default the `inventory_hostname` as mailcow hostname, this
 |     `mailcow__redirect_http_to_https`     |         if `yes`, all requests via HTTP will be redirected to HTTPS         |           `no`            | also see https://mailcow.github.io/mailcow-dockerized-docs/u_e-80_to_443/ |
 |      `mailcow__config_acme_contact`       |                      sets ACME_CONTACT in mailcow.conf                      |                           |                                                                           |
 |      `mailcow__rspamd_clamd_servers`      |                 configures the clamd server used by rspamd                  |       `clamd:3310`        |                                                                           |
+|     `mailcow__ipv6`     |         if `no`, IPv6 will be disabled         |           `yes`            | also see https://docs.mailcow.email/post_installation/firststeps-disable_ipv6/ |
 
 ## Usage
 

--- a/defaults/main/main.yml
+++ b/defaults/main/main.yml
@@ -21,3 +21,6 @@ mailcow__install_updates: yes
 mailcow__redirect_http_to_https: no
 
 mailcow__rspamd_clamd_servers: clamd:3310
+
+# Enable IPv6 by default
+mailcow__ipv6: yes

--- a/tasks/ipv6_config.yml
+++ b/tasks/ipv6_config.yml
@@ -1,0 +1,51 @@
+---
+
+- name: Set required facts to disable IPv6
+  set_fact:
+    mailcow__ipv6_unbound: "no"
+    mailcow__ipv6_postfix_lines: "present"
+  when: not mailcow__ipv6 | bool
+
+- name: Set required facts to enable IPv6
+  set_fact:
+    mailcow__ipv6_unbound: "yes"
+    mailcow__ipv6_postfix_lines: "absent"
+  when: mailcow__ipv6 | bool
+
+- name: "Configure Unbound"
+  become: yes
+  replace:
+    path: "{{ mailcow__install_path }}/data/conf/unbound/unbound.conf"
+    regexp: "^do-ip6:.*"
+    replace: "do-ip6: {{ mailcow__ipv6_unbound }}"
+  notify: Recreate mailcow
+
+- name: "Configure Postfix"
+  become: yes
+  lineinfile:
+    path: "{{ mailcow__install_path }}/data/conf/postfix/extra.cf"
+    regexp: "^{{ item.variable }}=.*"
+    line: "{{ item.variable }} = {{ item.value }}"
+    state: "{{ mailcow__ipv6_postfix_lines }}"
+  notify: Recreate mailcow
+  loop:
+    - variable: "smtp_address_preference"
+      value: "ipv4"
+    - variable: "inet_protocols"
+      value: "ipv4"
+
+- name: "Override docker-compose to disable IPv6"
+  become: yes
+  template:
+    src: docker-compose.override.yml.j2
+    dest: "{{ mailcow__install_path }}/docker-compose.override.yml"
+  notify: Recreate mailcow
+  when: not mailcow__ipv6 | bool
+
+- name: "Make sure docker-compose.override.yml is removed"
+  become: yes
+  file:
+    path: "{{ mailcow__install_path }}/docker-compose.override.yml"
+    state: absent
+  notify: Recreate mailcow
+  when: mailcow__ipv6 | bool

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -64,6 +64,10 @@
     chdir: "{{ mailcow__install_path }}"
   when: not mailcow_running.exists
 
+- name: Set IPv6 to {{ mailcow__ipv6 }}
+  include_tasks: ipv6_config.yml
+  when: mailcow_running.exists
+
 - name: Update mailcow
   include_tasks: update.yml
   when:

--- a/templates/docker-compose.override.yml.j2
+++ b/templates/docker-compose.override.yml.j2
@@ -1,0 +1,16 @@
+---
+version: '2.1'
+services:
+  ipv6nat-mailcow:
+    image: bash:latest
+    restart: "no"
+    entrypoint: ["echo", "ipv6nat disabled in compose.override.yml"]
+
+networks:
+  mailcow-network:
+    enable_ipv6: false
+    ipam:
+      driver: default
+      config:
+        - subnet: ${IPV4_NETWORK:-172.22.1}.0/24
+...


### PR DESCRIPTION
This PR adds a flag to disable IPv6.

It basically reproduces the steps in the official [documentation](https://docs.mailcow.email/post_installation/firststeps-disable_ipv6/) and can be handy, if you only have an IPv4 address.

To disable IPv6, set `mailcow__ipv6: 'no'` in your host- or group_vars, if changed back to mailcow__ipv6: 'yes' or if you delete the option, all changes get rolled back and IPv6 is enabled again.

I did this mainly to get rid of the alerts from the watchdog, which tells me that IPv6 is not working on my host.