### PR TITLE
Use docker compose cli plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ This role will use by default the `inventory_hostname` as mailcow hostname, this
 |     `mailcow__redirect_http_to_https`     |         if `yes`, all requests via HTTP will be redirected to HTTPS         |           `no`            | also see https://mailcow.github.io/mailcow-dockerized-docs/u_e-80_to_443/ |
 |      `mailcow__config_acme_contact`       |                      sets ACME_CONTACT in mailcow.conf                      |                           |                                                                           |
 |      `mailcow__rspamd_clamd_servers`      |                 configures the clamd server used by rspamd                  |       `clamd:3310`        |                                                                           |
+|        `mailcow__compose_command`         |               configures the command that is used for compose               |     `docker compose`      |      set to `docker-compose` for the standalone version of compose        |
 
 ## Usage
 

--- a/defaults/main/main.yml
+++ b/defaults/main/main.yml
@@ -21,3 +21,6 @@ mailcow__install_updates: yes
 mailcow__redirect_http_to_https: no
 
 mailcow__rspamd_clamd_servers: clamd:3310
+
+# Change this to "docker-compose" if you use the standalone version of compose
+mailcow__compose_command: docker compose

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -3,21 +3,21 @@
 - name: Restart mailcow
   become: yes
   shell: |
-    docker-compose --project-name {{ mailcow__docker_compose_project_name }} restart
+    {{ mailcow__compose_command }} --project-name {{ mailcow__docker_compose_project_name }} restart
   args:
     chdir: "{{ mailcow__install_path }}"
 
 - name: Recreate mailcow
   become: yes
   shell: |
-    docker-compose --project-name {{ mailcow__docker_compose_project_name }} down
-    docker-compose --project-name {{ mailcow__docker_compose_project_name }} up -d
+    {{ mailcow__compose_command }} --project-name {{ mailcow__docker_compose_project_name }} down
+    {{ mailcow__compose_command }} --project-name {{ mailcow__docker_compose_project_name }} up -d
   args:
     chdir: "{{ mailcow__install_path }}"
 
 - name: Restart mailcow rspamd
   become: yes
   shell: |
-    docker-compose --project-name {{ mailcow__docker_compose_project_name }} restart rspamd-mailcow
+    {{ mailcow__compose_command }} --project-name {{ mailcow__docker_compose_project_name }} restart rspamd-mailcow
   args:
     chdir: "{{ mailcow__install_path }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -59,7 +59,7 @@
 - name: Start mailcow container stack
   become: yes
   shell: |
-    docker-compose --project-name {{ mailcow__docker_compose_project_name }} up -d
+    {{ mailcow__compose_command }} --project-name {{ mailcow__docker_compose_project_name }} up -d
   args:
     chdir: "{{ mailcow__install_path }}"
   when: not mailcow_running.exists


### PR DESCRIPTION
Fixes #35 by adding an option to specify the docker compose command. I set the default to `docker compose` since both the mailcow docs as well as the upstream docker install instruction now use the docker cli plugin.
The new option is named `mailcow__compose_command`.