### PR TITLE
Ensuring that any files created by the generate_config script will have the correct permissions

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -23,7 +23,9 @@
   when: not mailcow_installed.stat.exists
 
 - name: Generate mailcow.conf file
-  shell: ./generate_config.sh
+  shell: |
+    umask 0022
+    ./generate_config.sh
   environment:
     MAILCOW_HOSTNAME: "{{ mailcow__hostname }}"
     MAILCOW_TZ: "{{ mailcow__timezone }}"


### PR DESCRIPTION
`Fatal error: Uncaught Error: Failed opening required '/web/inc/app_info.inc.php' (include_path='.:/usr/local/lib/php') in /web/inc/prerequisites.inc.php:24 Stack trace: #0 /web/index.php(2): require_once() #1 {main} thrown in /web/inc/prerequisites.inc.php on line 24`

When running a role on an instance with `umask 027` set at the system level, I received this error when opening https://$MAILCOW_HOSTNAME. As I understand it, PHP couldn't read the [file](https://github.com/mailcow/mailcow-dockerized/blob/37beed6ad93f259b97cad41877982bce95295629/data/web/inc/prerequisites.inc.php#L22) it needed. [The documentation](https://docs.mailcow.email/getstarted/install/#install-mailcow) states that we need to set the required `umask 0022` parameter manually only at the stage of cloning the repo, but maybe it would be more correct to set this parameter also for generate_config script?