### PR TITLE
feat: allow overwrite of DB{PASS,ROOT} and REDISPASS

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,9 @@ This role will use by default the `inventory_hostname` as mailcow hostname, this
 |     `mailcow__rspamd_clamd_patterns`      |    configures custom clamd rspamd patterns inside rspamd antivirus.conf     |                                                     |             needs to be a list  of name and regex             |
 |        `mailcow__compose_command`         |               configures the command that is used for compose               |                  `docker compose`                   | set to `docker-compose` for the standalone version of compose |
 |       `mailcow__config_enable_ipv6`       |                      sets ENABLE_IPV6 in mailcow.conf                       |                       `true`                        |   Enables IPv6 support in mailcow, can be `true` or `false`   |
+|             `mailcow__dbpass`             |                          sets DBPASS in mailcow.conf                        |                       not set                       |   If not set - a random password is created (recommended)     |
+|             `mailcow__dbroot`             |                          sets DBROOT in mailcow.conf                        |                       not set                       |   If not set - a random password is created (recommended)     |
+|            `mailcow__redispass`           |                         sets REDISPASS in mailcow.conf                      |                       not set                       |   If not set - a random password is created (recommended)     |
 
 > [!WARNING]
 > Please take close attention to the variable `mailcow__config_enable_ipv6` as this value is a boolean instead of a string.

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -35,6 +35,9 @@
     MAILCOW_HOSTNAME: "{{ mailcow__hostname }}"
     MAILCOW_TZ: "{{ mailcow__timezone }}"
     MAILCOW_BRANCH: "{{ mailcow__git_version }}"
+    MAILCOW_DBPASS: "{{ mailcow__dbpass | default(omit) }}"
+    MAILCOW_DBROOT: "{{ mailcow__dbroot | default(omit) }}"
+    MAILCOW_REDISPASS: "{{ mailcow__redispass | default(omit) }}"
   args:
     executable: /bin/bash
     chdir: "{{ mailcow__install_path }}"


### PR DESCRIPTION
This PR depends on merge of https://github.com/mailcow/mailcow-dockerized/pull/7007

When any of the following Ansible (inventory) variables are set:
- `mailcow__dbpass`
- `mailcow__dbroot`
- `mailcow__redispass`

They will be passed as extra Environment variables when running `generate_config.sh` via Ansible to create the `mailcow.conf`.

If not present the original behavior is kept in place and the `generate_config.sh` script is creating random password strings. See mentioned PR for details.